### PR TITLE
Add depo ID and islemTip to material selection modals

### DIFF
--- a/src/pages/Malzeme&DepoYonetimi/CikisFisleri/Insert/components/SecondTabs/components/FisIcerigi/FisIcerigi.jsx
+++ b/src/pages/Malzeme&DepoYonetimi/CikisFisleri/Insert/components/SecondTabs/components/FisIcerigi/FisIcerigi.jsx
@@ -108,7 +108,7 @@ const EditableCell = ({ title, editable, children, dataIndex, record, handleSave
   );
 };
 
-const MalzemeSecModal = ({ visible, onCancel, onOk }) => {
+const MalzemeSecModal = ({ visible, onCancel, onOk, deposuID }) => {
   const [selectedRows, setSelectedRows] = useState([]);
   const [modalKey, setModalKey] = useState(Date.now());
 
@@ -125,7 +125,7 @@ const MalzemeSecModal = ({ visible, onCancel, onOk }) => {
 
   return (
     <Modal title="Malzeme Seç" open={visible} onCancel={onCancel} onOk={() => onOk(selectedRows)} width={1200} style={{ top: 20 }} destroyOnClose>
-      <Malzemeler key={modalKey} onRowSelect={handleMalzemeSelect} isSelectionMode={true} />
+      <Malzemeler key={modalKey} onRowSelect={handleMalzemeSelect} isSelectionMode={true} deposuID={deposuID} islemTip="C" />
     </Modal>
   );
 };
@@ -137,6 +137,9 @@ function FisIcerigi({ modalOpen }) {
   const [currentEditingRow, setCurrentEditingRow] = useState(null);
   const [previousModalState, setPreviousModalState] = useState(false);
   const [isIndirimManuallyEdited, setIsIndirimManuallyEdited] = useState(false);
+
+  // Watch for girisDeposuID to control button state
+  const girisDeposuID = watch("girisDeposuID");
 
   const { fields, append, remove, replace } = useFieldArray({
     control,
@@ -505,14 +508,14 @@ function FisIcerigi({ modalOpen }) {
       editable: false,
       inputType: "text",
     },
-    {
+    /* {
       title: "Malzeme Tipi",
       dataIndex: "malzemeTipi",
       key: "malzemeTipi",
       width: 150,
       editable: false,
       inputType: "text",
-    },
+    }, */
     {
       title: "Miktar",
       dataIndex: "miktar",
@@ -771,7 +774,7 @@ function FisIcerigi({ modalOpen }) {
   return (
     <div style={{ marginTop: "-55px", zIndex: 10 }}>
       <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 16 }}>
-        <Button style={{ zIndex: 21 }} type="primary" icon={<PlusOutlined />} onClick={() => setIsModalVisible(true)}>
+        <Button style={{ zIndex: 21 }} type="primary" icon={<PlusOutlined />} onClick={() => setIsModalVisible(true)} disabled={!girisDeposuID}>
           Ekle
         </Button>
       </div>
@@ -969,7 +972,7 @@ function FisIcerigi({ modalOpen }) {
         </div>
       </div>
 
-      <MalzemeSecModal visible={isModalVisible} onCancel={() => setIsModalVisible(false)} onOk={handleMalzemeSelect} />
+      <MalzemeSecModal visible={isModalVisible} onCancel={() => setIsModalVisible(false)} onOk={handleMalzemeSelect} deposuID={girisDeposuID} />
     </div>
   );
 }

--- a/src/pages/Malzeme&DepoYonetimi/CikisFisleri/Update/components/SecondTabs/components/FisIcerigi/FisIcerigi.jsx
+++ b/src/pages/Malzeme&DepoYonetimi/CikisFisleri/Update/components/SecondTabs/components/FisIcerigi/FisIcerigi.jsx
@@ -108,7 +108,7 @@ const EditableCell = ({ title, editable, children, dataIndex, record, handleSave
   );
 };
 
-const MalzemeSecModal = ({ visible, onCancel, onOk }) => {
+const MalzemeSecModal = ({ visible, onCancel, onOk, deposuID }) => {
   const [selectedRows, setSelectedRows] = useState([]);
   const [modalKey, setModalKey] = useState(Date.now());
 
@@ -125,7 +125,7 @@ const MalzemeSecModal = ({ visible, onCancel, onOk }) => {
 
   return (
     <Modal title="Malzeme Seç" open={visible} onCancel={onCancel} onOk={() => onOk(selectedRows)} width={1200} style={{ top: 20 }} destroyOnClose>
-      <Malzemeler key={modalKey} onRowSelect={handleMalzemeSelect} isSelectionMode={true} />
+      <Malzemeler key={modalKey} onRowSelect={handleMalzemeSelect} isSelectionMode={true} deposuID={deposuID} islemTip="C" />
     </Modal>
   );
 };
@@ -137,6 +137,9 @@ function FisIcerigi({ modalOpen }) {
   const [currentEditingRow, setCurrentEditingRow] = useState(null);
   const [previousModalState, setPreviousModalState] = useState(false);
   const [isIndirimManuallyEdited, setIsIndirimManuallyEdited] = useState(false);
+
+  // Watch for girisDeposuID to control button state
+  const girisDeposuID = watch("girisDeposuID");
 
   const { fields, append, remove, replace } = useFieldArray({
     control,
@@ -505,7 +508,7 @@ function FisIcerigi({ modalOpen }) {
       editable: false,
       inputType: "text",
     },
-    /*  {
+    /* {
       title: "Malzeme Tipi",
       dataIndex: "malzemeTipi",
       key: "malzemeTipi",
@@ -771,7 +774,7 @@ function FisIcerigi({ modalOpen }) {
   return (
     <div style={{ marginTop: "-55px", zIndex: 10 }}>
       <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 16 }}>
-        <Button style={{ zIndex: 21 }} type="primary" icon={<PlusOutlined />} onClick={() => setIsModalVisible(true)}>
+        <Button style={{ zIndex: 21 }} type="primary" icon={<PlusOutlined />} onClick={() => setIsModalVisible(true)} disabled={!girisDeposuID}>
           Ekle
         </Button>
       </div>
@@ -969,7 +972,7 @@ function FisIcerigi({ modalOpen }) {
         </div>
       </div>
 
-      <MalzemeSecModal visible={isModalVisible} onCancel={() => setIsModalVisible(false)} onOk={handleMalzemeSelect} />
+      <MalzemeSecModal visible={isModalVisible} onCancel={() => setIsModalVisible(false)} onOk={handleMalzemeSelect} deposuID={girisDeposuID} />
     </div>
   );
 }

--- a/src/pages/Malzeme&DepoYonetimi/MalzemeTanimlari/Table/Table.jsx
+++ b/src/pages/Malzeme&DepoYonetimi/MalzemeTanimlari/Table/Table.jsx
@@ -123,7 +123,7 @@ const DraggableRow = ({ id, text, index, moveRow, className, style, visible, onV
 
 // Sütunların sürüklenebilir olmasını sağlayan component sonu
 
-const Sigorta = ({ onRowSelect, isSelectionMode = false }) => {
+const Sigorta = ({ onRowSelect, isSelectionMode = false, islemTip = null, deposuID = null }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   let setValue;
 
@@ -911,8 +911,21 @@ const Sigorta = ({ onRowSelect, isSelectionMode = false }) => {
 
     try {
       setLoading(true);
-      // API isteğinde keyword ve currentPage kullanılıyor
-      const response = await AxiosInstance.get(`Stok?modulNo=1&page=${currentPage}&prm=${keyword}`);
+
+      // islemTip değerine göre API URL'ini oluştur
+      let apiUrl = `Stok?modulNo=1&page=${currentPage}&prm=${keyword}`;
+
+      if (islemTip === "C" || islemTip === "T") {
+        // islemTip C veya T ise özel parametreler ekle
+        apiUrl += `&islemTip=${islemTip}&depoId=${deposuID || 1}`;
+      } else {
+        // islemTip null ise normal parametreler ekle
+        apiUrl;
+      }
+
+      // API isteğini yap
+      const response = await AxiosInstance.get(apiUrl);
+
       if (response) {
         // Toplam sayfa sayısını ayarla
         setTotalPages(response.page);

--- a/src/pages/Malzeme&DepoYonetimi/TransferFisleri/Insert/components/SecondTabs/components/FisIcerigi/FisIcerigi.jsx
+++ b/src/pages/Malzeme&DepoYonetimi/TransferFisleri/Insert/components/SecondTabs/components/FisIcerigi/FisIcerigi.jsx
@@ -108,7 +108,7 @@ const EditableCell = ({ title, editable, children, dataIndex, record, handleSave
   );
 };
 
-const MalzemeSecModal = ({ visible, onCancel, onOk }) => {
+const MalzemeSecModal = ({ visible, onCancel, onOk, deposuID }) => {
   const [selectedRows, setSelectedRows] = useState([]);
   const [modalKey, setModalKey] = useState(Date.now());
 
@@ -125,7 +125,7 @@ const MalzemeSecModal = ({ visible, onCancel, onOk }) => {
 
   return (
     <Modal title="Malzeme Seç" open={visible} onCancel={onCancel} onOk={() => onOk(selectedRows)} width={1200} style={{ top: 20 }} destroyOnClose>
-      <Malzemeler key={modalKey} onRowSelect={handleMalzemeSelect} isSelectionMode={true} />
+      <Malzemeler key={modalKey} onRowSelect={handleMalzemeSelect} isSelectionMode={true} deposuID={deposuID} islemTip="T" />
     </Modal>
   );
 };
@@ -137,6 +137,9 @@ function FisIcerigi({ modalOpen }) {
   const [currentEditingRow, setCurrentEditingRow] = useState(null);
   const [previousModalState, setPreviousModalState] = useState(false);
   const [isIndirimManuallyEdited, setIsIndirimManuallyEdited] = useState(false);
+
+  // Watch for girisDeposuID to control button state
+  const girisDeposuID = watch("cikisDeposuID");
 
   const { fields, append, remove, replace } = useFieldArray({
     control,
@@ -505,14 +508,14 @@ function FisIcerigi({ modalOpen }) {
       editable: false,
       inputType: "text",
     },
-    {
+    /* {
       title: "Malzeme Tipi",
       dataIndex: "malzemeTipi",
       key: "malzemeTipi",
       width: 150,
       editable: false,
       inputType: "text",
-    },
+    }, */
     {
       title: "Miktar",
       dataIndex: "miktar",
@@ -771,7 +774,7 @@ function FisIcerigi({ modalOpen }) {
   return (
     <div style={{ marginTop: "-55px", zIndex: 10 }}>
       <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 16 }}>
-        <Button style={{ zIndex: 21 }} type="primary" icon={<PlusOutlined />} onClick={() => setIsModalVisible(true)}>
+        <Button style={{ zIndex: 21 }} type="primary" icon={<PlusOutlined />} onClick={() => setIsModalVisible(true)} disabled={!girisDeposuID}>
           Ekle
         </Button>
       </div>
@@ -969,7 +972,7 @@ function FisIcerigi({ modalOpen }) {
         </div>
       </div>
 
-      <MalzemeSecModal visible={isModalVisible} onCancel={() => setIsModalVisible(false)} onOk={handleMalzemeSelect} />
+      <MalzemeSecModal visible={isModalVisible} onCancel={() => setIsModalVisible(false)} onOk={handleMalzemeSelect} deposuID={girisDeposuID} />
     </div>
   );
 }

--- a/src/pages/Malzeme&DepoYonetimi/TransferFisleri/Update/components/SecondTabs/components/FisIcerigi/FisIcerigi.jsx
+++ b/src/pages/Malzeme&DepoYonetimi/TransferFisleri/Update/components/SecondTabs/components/FisIcerigi/FisIcerigi.jsx
@@ -108,7 +108,7 @@ const EditableCell = ({ title, editable, children, dataIndex, record, handleSave
   );
 };
 
-const MalzemeSecModal = ({ visible, onCancel, onOk }) => {
+const MalzemeSecModal = ({ visible, onCancel, onOk, deposuID }) => {
   const [selectedRows, setSelectedRows] = useState([]);
   const [modalKey, setModalKey] = useState(Date.now());
 
@@ -125,7 +125,7 @@ const MalzemeSecModal = ({ visible, onCancel, onOk }) => {
 
   return (
     <Modal title="Malzeme Seç" open={visible} onCancel={onCancel} onOk={() => onOk(selectedRows)} width={1200} style={{ top: 20 }} destroyOnClose>
-      <Malzemeler key={modalKey} onRowSelect={handleMalzemeSelect} isSelectionMode={true} />
+      <Malzemeler key={modalKey} onRowSelect={handleMalzemeSelect} isSelectionMode={true} deposuID={deposuID} islemTip="T" />
     </Modal>
   );
 };
@@ -137,6 +137,9 @@ function FisIcerigi({ modalOpen }) {
   const [currentEditingRow, setCurrentEditingRow] = useState(null);
   const [previousModalState, setPreviousModalState] = useState(false);
   const [isIndirimManuallyEdited, setIsIndirimManuallyEdited] = useState(false);
+
+  // Watch for girisDeposuID to control button state
+  const girisDeposuID = watch("cikisDeposuID");
 
   const { fields, append, remove, replace } = useFieldArray({
     control,
@@ -505,7 +508,7 @@ function FisIcerigi({ modalOpen }) {
       editable: false,
       inputType: "text",
     },
-    /*  {
+    /* {
       title: "Malzeme Tipi",
       dataIndex: "malzemeTipi",
       key: "malzemeTipi",
@@ -771,7 +774,7 @@ function FisIcerigi({ modalOpen }) {
   return (
     <div style={{ marginTop: "-55px", zIndex: 10 }}>
       <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 16 }}>
-        <Button style={{ zIndex: 21 }} type="primary" icon={<PlusOutlined />} onClick={() => setIsModalVisible(true)}>
+        <Button style={{ zIndex: 21 }} type="primary" icon={<PlusOutlined />} onClick={() => setIsModalVisible(true)} disabled={!girisDeposuID}>
           Ekle
         </Button>
       </div>
@@ -969,7 +972,7 @@ function FisIcerigi({ modalOpen }) {
         </div>
       </div>
 
-      <MalzemeSecModal visible={isModalVisible} onCancel={() => setIsModalVisible(false)} onOk={handleMalzemeSelect} />
+      <MalzemeSecModal visible={isModalVisible} onCancel={() => setIsModalVisible(false)} onOk={handleMalzemeSelect} deposuID={girisDeposuID} />
     </div>
   );
 }


### PR DESCRIPTION
Material selection modals in CikisFisleri and TransferFisleri now receive deposuID and islemTip props, enabling API filtering based on depot and operation type. The 'Ekle' button is disabled until a relevant depot is selected. API calls in MalzemeTanimlari table are updated to support these new parameters for more accurate material listing.