### PR TITLE
Update API endpoint in EditDrawer for machine downtime tracking

### DIFF
--- a/src/pages/MakineEkipman/DurusTakibi/Update/EditDrawer.jsx
+++ b/src/pages/MakineEkipman/DurusTakibi/Update/EditDrawer.jsx
@@ -157,7 +157,7 @@ export default function EditModal({ selectedRow, onDrawerClose, drawerVisible, o
     };
 
     // API'ye POST isteği gönder
-    AxiosInstance.post("UpdateMakineDurus", Body)
+    AxiosInstance.post(`UpdateMakineDurusBy?durusId=${selectedRow.TB_MAKINE_DURUS_ID}`, Body)
       .then((response) => {
         console.log("Data sent successfully:", response);
         if (response.status_code === 200 || response.status_code === 201 || response.status_code === 202) {


### PR DESCRIPTION
Modified the API POST request in the EditDrawer component to include the machine downtime ID in the endpoint URL, enhancing data accuracy during updates. This change ensures that the correct downtime record is targeted for updates, improving the overall functionality of the downtime tracking feature.